### PR TITLE
Readme heading tag formatting.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@
      * [Receiving response from the SDK](#receiving-response-from-the-sdk)
    * [Using Custom UI](#using-custom-ui)
     
-##***Note:SDK currently does not support MarketPlace Integration. MarketPlace API Documentation is available [here](https://docs.instamojo.com/v2/docs)***
+> #### ***Note: SDK currently does not support MarketPlace Integration. MarketPlace API Documentation is available [here](https://docs.instamojo.com/v2/docs)***
 
 ## Overview
 This SDK allows you to integrate payments via Instamojo into your Android app. It currently supports following modes of payments:


### PR DESCRIPTION
The Note for MarketPlace not supported in Readme was not  marked properly with the header tag.
Fixed that by replacing with header in quote tag.